### PR TITLE
Set default exposure params

### DIFF
--- a/lighttable_exposure_controls.lua
+++ b/lighttable_exposure_controls.lua
@@ -74,7 +74,7 @@ local function get_current_exposure(image)
     xmp:close()
 
     local highest_num = -1
-    local latest_params = nil
+    local latest_params = "00000000000000000000000000004842000080c000000000"
 
     -- Match each block containing the exposure operation
     for block in content:gmatch("<rdf:li.-/>") do


### PR DESCRIPTION
Initialize latest_params with a default value instead of nil to ensure a valid exposure parameter is available when no matching block is found.

Fixes issue where images without exposure history are unable to be adjusted.

Tested in darktable 5.2.0|5.4.1 - Lua API 9.5.0